### PR TITLE
Set Up TypeScript Compilation Support for CI Test Scripts

### DIFF
--- a/.github/workflows/auto_test_suite.yml
+++ b/.github/workflows/auto_test_suite.yml
@@ -13,8 +13,15 @@ jobs:
         steps:
         - name: Check-out repo
           uses: actions/checkout@v4
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+            node-version: '20'
+            cache: 'npm'
         - name: install dependencies
           run: npm install
+        - name: Compile TypeScript CI scripts
+          run: npm run build:tests
         - name: Auto Test Suite
           run: npm run ci-check
             

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "expo lint",
     "test:build": "npx expo export",
     "ci-check": "node ./scripts/ci-check.js",
-    "test": "cucumber-js"
+    "test": "cucumber-js",
+    "build:tests": "tsc src/tests/suites/auto_test_suite.ts --outDir build/ci-build --module commonjs --target es6"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/scripts/ci-check.js
+++ b/scripts/ci-check.js
@@ -13,11 +13,25 @@ function runStep(stepName, command){
     console.log("\n///////////////////////////////////////////////////////////////////////\n")
 }
 
+//Verify that compiled JavaScript files can be imported cleanly into ci-check.js
+function runInternalCheck(stepName, checkLogic) {
+    console.log(`\nTest: ${stepName}`);
+    console.log(`\nAction: Internal JavaScript Verification`);
+    checkLogic(); // Execute the logic
+    console.log("\n///////////////////////////////////////////////////////////////////////\n");
+}
+
 function main(){
     banner("AUTO TEST SUITE RUNNING");
 
     runStep("Lint (Expo ESLint)", "npm run lint");
     runStep("Build Export (Expo export)", "npm run test:build");
+
+    //Ensure that auto_test_suite.js file was properly created in build folder
+    runInternalCheck("Verify Compiled TS Suite", () => {
+        const tsSuite = require('../build/ci-build/auto_test_suite.js');
+        console.log(`Successfully integrated: ${tsSuite.testSuiteMetadata.name}`);
+    });
 
     //(UNCOMMENT TO USE)
     //Test to verify the FAILED tests are correctly logged.

--- a/src/tests/suites/auto_test_suite.ts
+++ b/src/tests/suites/auto_test_suite.ts
@@ -1,0 +1,10 @@
+// src/tests/suites/auto_test_suite.ts
+/**
+ * Placeholder for the TypeScript-based Auto Test Suite logic.
+ * This file will eventually house the Customer Ordering and Payment test integrations.
+ */
+export const testSuiteMetadata = {
+  name: "Automated TS Test Suite",
+  version: "1.0.0",
+  status: "initialized"
+};


### PR DESCRIPTION
Here are the files for the TypeScript compilation support for CI Test Scripts.

Initially, the plan was to generate the auto_test_suite.js file inside the dist directory. However, since "test:build": "npx expo export" clears and regenerates the .../dist directory, this approach would not reliably meet the task requirements. Any compiled file placed there could be removed during the build process. 

One workaround would be to generate auto_test_suite.js inside the .../dist directory after running the "test:build" script. However, this would defeat the purpose of validating the test setup before the final ci-check, since the compilation would depend on a later step rather than being independently verified.

To avoid that conflict, the output of auto_test_suite.ts is now directed to the build folder, as specified in the build:tests script in package.json.

A verification step was also added to ci-check.js to confirm that auto_test_suite.js is created successfully.

In addition, the auto_test_suite.yaml workflow was updated to use Node.js 20. Before running ci-check, the workflow now executes build:tests, which compiles auto_test_suite.ts and outputs the result to build/ci-build/auto_test_suite.js.