### PR TITLE
fix: refactor signup to use ThemedText and project theme system

### DIFF
--- a/src/app/signup/index.tsx
+++ b/src/app/signup/index.tsx
@@ -97,6 +97,7 @@ function InputField({
 // ─── PasswordChecklist ────────────────────────────────────────────────────────
 function PasswordChecklist({ password }: { password: string }) {
   const textColor = useThemeColor({}, 'text');
+  const defaultColor = useThemeColor({ light: Colors.light.text, dark: Colors.dark.text }, 'text');
   const checks = [
     { label: 'At least 8 characters', met: password.length >= 8 },
     { label: 'At least 1 lowercase', met: /[a-z]/.test(password) },
@@ -107,12 +108,18 @@ function PasswordChecklist({ password }: { password: string }) {
     <View style={styles.checklistContainer}>
       {checks.map((c) => (
         <View key={c.label} style={styles.checklistRow}>
-          <ThemedText style={{ color: c.met ? Colors.primaryGreen : Colors.mutedGray, fontSize: 16 }}>
-            ✔
+          <ThemedText 
+            type="body" 
+            style={{ 
+              fontSize: 14, 
+              color: c.met ? Colors.primaryGreen : defaultColor 
+            }}
+          >
+            ✓
           </ThemedText>
           <ThemedText
             type="body"
-            style={[styles.checklistText, { color: c.met ? textColor : Colors.mutedGray }]}
+            style={[styles.checklistText, { color: textColor }]}
           >
             {' '}{c.label}
           </ThemedText>


### PR DESCRIPTION
Follow-up fix for Sign Up page 

## Summary

Refactors the Sign Up page to use the project's existing theme system per team lead feedback:

* Removed custom Google Fonts URL loading (was causing Expo Go to hang on mobile)
* Replaced `Text` with `ThemedText` using the project's theme system (`@/components/themed-text`)
* Replaced local color tokens with `Colors` from `@/constants/theme`
* Removed all `fontFamily` references — typography is now handled by the theme
* Improved eye icon contrast on password fields
* All existing functionality preserved (auth context, confirm password, onBlur validation, router navigation)

## Files Modified

* `src/app/signup/index.tsx`

## How to Review

1. Run `npm install` then `npx expo start`
2. Navigate to `/signup` on web or scan QR with Expo Go
3. Verify all input fields, buttons, and links render correctly
4. Confirm the page loads immediately (no font loading spinner)
5. Toggle dark/light mode and confirm styling adapts
6. Test form validation and submission flow