### PR TITLE
Add Supabase Auth Session Creation Test and related documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:build": "npx expo export",
     "ci-check": "node ./scripts/ci-check.js",
     "test:cucumber": "cucumber-js",
+    "test:supabase:auth-session": "npx tsx src/tests/supabase/scripts/auth-session.test.ts",
     "build:tests": "tsc src/tests/suites/auto_test_suite.ts --outDir build/ci-build --module commonjs --target es6",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",

--- a/src/tests/supabase/cases/TC-SUPA-03_auth_session_creation_validation.ts
+++ b/src/tests/supabase/cases/TC-SUPA-03_auth_session_creation_validation.ts
@@ -1,0 +1,60 @@
+/*
+Supabase Auth Session Creation Validation TC
+Author: Luis J.
+
+Description
+Validate that an authentication event produces a usable session in Supabase JS,
+that the session is retrievable with getSession(), and that signOut clears it.
+Test type: Integration / Smoke
+
+Preconditions
+* `.env` exists with valid Supabase credentials.
+* `.env` includes a confirmed test user:
+  - SUPABASE_TEST_LOGIN_EMAIL
+  - SUPABASE_TEST_LOGIN_PASSWORD
+* Dependencies installed (`npm install`).
+* Script file `src/tests/supabase/scripts/auth-session.test.ts` is available.
+
+Test Data
+Env Vars:
+- EXPO_PUBLIC_SUPABASE_URL
+- EXPO_PUBLIC_SUPABASE_ANON_KEY
+- SUPABASE_TEST_LOGIN_EMAIL
+- SUPABASE_TEST_LOGIN_PASSWORD
+
+Test Steps
+. Run: `npx tsx src/tests/supabase/scripts/auth-session.test.ts`.
+. Verify script signs out first (clean slate).
+. Verify `signInWithPassword` returns a non-null `session` with `access_token`.
+. Verify `getSession()` returns the active session.
+. Verify `getUser()` resolves the authenticated user.
+. (Optional) Verify `refreshSession()` succeeds if `refresh_token` exists.
+. Verify `signOut()` clears the session.
+
+Expected Results
+* Script exits with status code 0.
+* Output includes PASS lines for each step.
+* Failures include actionable messages (missing env var, auth failure, etc.).
+
+Notes
+This test is designed to be fast (< 1 minute) and runnable before CI or demos.
+*/
+
+export const TC_SUPA_03_INPUT_VALUES = {
+  envVars: {
+    url: 'EXPO_PUBLIC_SUPABASE_URL',
+    anonKey: 'EXPO_PUBLIC_SUPABASE_ANON_KEY',
+    testEmail: 'SUPABASE_TEST_LOGIN_EMAIL',
+    testPassword: 'SUPABASE_TEST_LOGIN_PASSWORD',
+  },
+} as const;
+
+export const TC_SUPA_03_TEST_DATA = {
+  inputValues: TC_SUPA_03_INPUT_VALUES,
+  env: {
+    urlVarName: TC_SUPA_03_INPUT_VALUES.envVars.url,
+    anonKeyVarName: TC_SUPA_03_INPUT_VALUES.envVars.anonKey,
+    testEmailVarName: TC_SUPA_03_INPUT_VALUES.envVars.testEmail,
+    testPasswordVarName: TC_SUPA_03_INPUT_VALUES.envVars.testPassword,
+  },
+} as const;

--- a/src/tests/supabase/docs/testing-supabase-connection.adoc
+++ b/src/tests/supabase/docs/testing-supabase-connection.adoc
@@ -65,6 +65,23 @@ export default function App() {
 
 . Check the console in Expo Go or your browser for test results.
 
+== Auth Session Creation Test
+
+Use this when you need a quick “backend-auth sanity check” (login -> session -> sign out):
+
+[source,bash]
+----
+npm run test:supabase:auth-session
+----
+
+This requires a confirmed test user in your `.env`:
+
+[source,bash]
+----
+SUPABASE_TEST_LOGIN_EMAIL=test-user@example.com
+SUPABASE_TEST_LOGIN_PASSWORD=your-test-password
+----
+
 == Related Test Assets
 
 * Cases: `src/tests/supabase/cases/`

--- a/src/tests/supabase/reports/TR-SUPA-03_auth_session_creation_validation.adoc
+++ b/src/tests/supabase/reports/TR-SUPA-03_auth_session_creation_validation.adoc
@@ -46,11 +46,11 @@ Paste console output here:
 [PASS] Initial signOut (clean slate)
   Signed out (or no session existed)
 [PASS] signInWithPassword creates session
-  Session created for luisjomarcruz@gmail.com
+  Session created for (redacted)
 [PASS] getSession returns active session
-  Active session user_id=c8d6e790-503c-4a31-84ce-7f4b1b1fc05e
+  Active session user_id=(redacted)
 [PASS] getUser resolves authenticated user
-  getUser() ok: luisjomarcruz@gmail.com
+  getUser() ok: (redacted)
 [PASS] Optional: refreshSession (if supported)
   refreshSession ok
 [PASS] signOut clears session

--- a/src/tests/supabase/reports/TR-SUPA-03_auth_session_creation_validation.adoc
+++ b/src/tests/supabase/reports/TR-SUPA-03_auth_session_creation_validation.adoc
@@ -1,0 +1,73 @@
+= TR-SUPA-03 Supabase Auth Session Creation Validation
+Author: Luis J.
+:toc:
+
+*Date:* 2026-05-16
+
+*ID:* TR-SUPA-03
+
+*Test:* TC-SUPA-03 - Supabase Auth Session Creation Validation
+
+*Script:* `src/tests/supabase/scripts/auth-session.test.ts`
+
+*Pass/Fail Status:* PASS
+
+== Purpose
+Verify that authentication produces a usable session (access token + user), that the session can be retrieved via `getSession()`, and that `signOut()` clears it.
+
+== Preconditions
+- `.env` contains valid Supabase URL + anon key.
+- `.env` contains a confirmed test user:
+  - `SUPABASE_TEST_LOGIN_EMAIL`
+  - `SUPABASE_TEST_LOGIN_PASSWORD`
+
+== Execution
+Run:
+
+[source,bash]
+----
+npx tsx src/tests/supabase/scripts/auth-session.test.ts
+----
+
+== Evidence
+Paste console output here:
+
+[source]
+----
+> semester-project-cafeteria-ordering@1.0.0 test:supabase:auth-session
+> npx tsx src/tests/supabase/scripts/auth-session.test.ts
+
+[dotenv@17.3.1] injecting env (8) from .env -- tip: ⚙️  write to custom object with { processEnv: myObject }
+
+[TEST] Supabase Auth Session Creation
+
+[PASS] Environment variables
+  Required env vars present
+[PASS] Initial signOut (clean slate)
+  Signed out (or no session existed)
+[PASS] signInWithPassword creates session
+  Session created for luisjomarcruz@gmail.com
+[PASS] getSession returns active session
+  Active session user_id=c8d6e790-503c-4a31-84ce-7f4b1b1fc05e
+[PASS] getUser resolves authenticated user
+  getUser() ok: luisjomarcruz@gmail.com
+[PASS] Optional: refreshSession (if supported)
+  refreshSession ok
+[PASS] signOut clears session
+  Session cleared
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[SUMMARY] 7/7 steps passed
+[SUCCESS] Auth session creation verified.
+----
+
+== Results
+- Environment variables: PASS
+- signInWithPassword creates session: PASS
+- getSession returns session: PASS
+- getUser resolves user: PASS
+- refreshSession (optional): PASS
+- signOut clears session: PASS
+
+== Notes / Follow-ups
+- If the refresh step is skipped (no `refresh_token`), confirm your Supabase auth settings for the project.

--- a/src/tests/supabase/scripts/auth-session.test.ts
+++ b/src/tests/supabase/scripts/auth-session.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Supabase Auth Session Creation Test
+ *
+ * Purpose:
+ * - Confirm that authentication creates a Supabase session (access_token + user)
+ * - Confirm session can be retrieved via getSession()
+ * - Confirm signOut clears the session
+ *
+ * Run:
+ *   npx tsx src/tests/supabase/scripts/auth-session.test.ts
+ *
+ * Requires .env:
+ * - EXPO_PUBLIC_SUPABASE_URL
+ * - EXPO_PUBLIC_SUPABASE_ANON_KEY
+ * - SUPABASE_TEST_LOGIN_EMAIL
+ * - SUPABASE_TEST_LOGIN_PASSWORD
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+type StepResult = {
+  name: string;
+  passed: boolean;
+  message: string;
+  error?: unknown;
+};
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing env var: ${name}`);
+  }
+  return value;
+}
+
+async function step(name: string, fn: () => Promise<string>): Promise<StepResult> {
+  try {
+    const message = await fn();
+    return { name, passed: true, message };
+  } catch (error: any) {
+    return {
+      name,
+      passed: false,
+      message: error?.message ?? 'Unknown error',
+      error,
+    };
+  }
+}
+
+async function main() {
+  console.log('\n[TEST] Supabase Auth Session Creation\n');
+
+  const results: StepResult[] = [];
+
+  const envCheck = await step('Environment variables', async () => {
+    // Supabase
+    requireEnv('EXPO_PUBLIC_SUPABASE_URL');
+    requireEnv('EXPO_PUBLIC_SUPABASE_ANON_KEY');
+
+    // Test user
+    requireEnv('SUPABASE_TEST_LOGIN_EMAIL');
+    requireEnv('SUPABASE_TEST_LOGIN_PASSWORD');
+
+    return 'Required env vars present';
+  });
+  results.push(envCheck);
+
+  if (!envCheck.passed) {
+    console.log('[FAIL] Environment is not configured.');
+    console.log('Add these to your .env (see .env.example):');
+    console.log('- EXPO_PUBLIC_SUPABASE_URL');
+    console.log('- EXPO_PUBLIC_SUPABASE_ANON_KEY');
+    console.log('- SUPABASE_TEST_LOGIN_EMAIL');
+    console.log('- SUPABASE_TEST_LOGIN_PASSWORD');
+    process.exit(1);
+  }
+
+  const supabaseUrl = requireEnv('EXPO_PUBLIC_SUPABASE_URL');
+  const supabaseAnonKey = requireEnv('EXPO_PUBLIC_SUPABASE_ANON_KEY');
+  const email = requireEnv('SUPABASE_TEST_LOGIN_EMAIL');
+  const password = requireEnv('SUPABASE_TEST_LOGIN_PASSWORD');
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+  results.push(
+    await step('Initial signOut (clean slate)', async () => {
+      const { error } = await supabase.auth.signOut();
+      if (error) throw error;
+      return 'Signed out (or no session existed)';
+    }),
+  );
+
+  results.push(
+    await step('signInWithPassword creates session', async () => {
+      const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) throw error;
+
+      if (!data.session) {
+        throw new Error('No session returned from signInWithPassword');
+      }
+      if (!data.session.access_token) {
+        throw new Error('Session missing access_token');
+      }
+      if (!data.user) {
+        throw new Error('No user returned from signInWithPassword');
+      }
+
+      return `Session created for ${data.user.email ?? '(no email)'}`;
+    }),
+  );
+
+  results.push(
+    await step('getSession returns active session', async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+      if (error) throw error;
+      if (!session) {
+        throw new Error('Expected an active session, got null');
+      }
+
+      return `Active session user_id=${session.user.id}`;
+    }),
+  );
+
+  results.push(
+    await step('getUser resolves authenticated user', async () => {
+      const { data, error } = await supabase.auth.getUser();
+      if (error) throw error;
+      if (!data.user) {
+        throw new Error('Expected getUser() to return a user');
+      }
+      return `getUser() ok: ${data.user.email ?? '(no email)'}`;
+    }),
+  );
+
+  results.push(
+    await step('Optional: refreshSession (if supported)', async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) throw error;
+      if (!session) {
+        throw new Error('No active session to refresh');
+      }
+
+      // Some projects/configs may not return refresh_token depending on settings.
+      if (!session.refresh_token) {
+        return 'Skipped: no refresh_token present on session';
+      }
+
+      const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
+      if (refreshError) throw refreshError;
+      if (!refreshed.session?.access_token) {
+        throw new Error('refreshSession did not return a valid session');
+      }
+
+      return 'refreshSession ok';
+    }),
+  );
+
+  results.push(
+    await step('signOut clears session', async () => {
+      const { error } = await supabase.auth.signOut();
+      if (error) throw error;
+
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (session) {
+        throw new Error('Expected no session after signOut, but session still exists');
+      }
+
+      return 'Session cleared';
+    }),
+  );
+
+  for (const r of results) {
+    console.log(`${r.passed ? '[PASS]' : '[FAIL]'} ${r.name}`);
+    console.log(`   ${r.message}`);
+    if (r.error) console.error('   Error:', r.error);
+  }
+
+  const passed = results.filter(r => r.passed).length;
+  console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`[SUMMARY] ${passed}/${results.length} steps passed`);
+
+  if (passed !== results.length) {
+    process.exit(1);
+  }
+
+  console.log('[SUCCESS] Auth session creation verified.\n');
+}
+
+main().catch(err => {
+  console.error('\n[FATAL]', err);
+  process.exit(1);
+});

--- a/src/tests/supabase/scripts/auth-session.test.ts
+++ b/src/tests/supabase/scripts/auth-session.test.ts
@@ -28,8 +28,7 @@ type StepResult = {
   error?: unknown;
 };
 
-function requireEnv(name: string): string {
-  const value = process.env[name];
+function requireEnvValue(value: string | undefined, name: string): string {
   if (!value) {
     throw new Error(`Missing env var: ${name}`);
   }
@@ -55,14 +54,19 @@ async function main() {
 
   const results: StepResult[] = [];
 
+  const supabaseUrlRaw = process.env.EXPO_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKeyRaw = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+  const emailRaw = process.env.SUPABASE_TEST_LOGIN_EMAIL;
+  const passwordRaw = process.env.SUPABASE_TEST_LOGIN_PASSWORD;
+
   const envCheck = await step('Environment variables', async () => {
     // Supabase
-    requireEnv('EXPO_PUBLIC_SUPABASE_URL');
-    requireEnv('EXPO_PUBLIC_SUPABASE_ANON_KEY');
+    requireEnvValue(supabaseUrlRaw, 'EXPO_PUBLIC_SUPABASE_URL');
+    requireEnvValue(supabaseAnonKeyRaw, 'EXPO_PUBLIC_SUPABASE_ANON_KEY');
 
     // Test user
-    requireEnv('SUPABASE_TEST_LOGIN_EMAIL');
-    requireEnv('SUPABASE_TEST_LOGIN_PASSWORD');
+    requireEnvValue(emailRaw, 'SUPABASE_TEST_LOGIN_EMAIL');
+    requireEnvValue(passwordRaw, 'SUPABASE_TEST_LOGIN_PASSWORD');
 
     return 'Required env vars present';
   });
@@ -78,10 +82,13 @@ async function main() {
     process.exit(1);
   }
 
-  const supabaseUrl = requireEnv('EXPO_PUBLIC_SUPABASE_URL');
-  const supabaseAnonKey = requireEnv('EXPO_PUBLIC_SUPABASE_ANON_KEY');
-  const email = requireEnv('SUPABASE_TEST_LOGIN_EMAIL');
-  const password = requireEnv('SUPABASE_TEST_LOGIN_PASSWORD');
+  const supabaseUrl = requireEnvValue(supabaseUrlRaw, 'EXPO_PUBLIC_SUPABASE_URL');
+  const supabaseAnonKey = requireEnvValue(
+    supabaseAnonKeyRaw,
+    'EXPO_PUBLIC_SUPABASE_ANON_KEY',
+  );
+  const email = requireEnvValue(emailRaw, 'SUPABASE_TEST_LOGIN_EMAIL');
+  const password = requireEnvValue(passwordRaw, 'SUPABASE_TEST_LOGIN_PASSWORD');
 
   const supabase = createClient(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
## Closes
#601 
## Summary
This PR adds a fast Supabase auth validation that confirms a session is created after login and can be retrieved and cleared successfully.

## What changed
- Added `src/tests/supabase/scripts/auth-session.test.ts`
- Added matching test case and report artifacts under `src/tests/supabase/cases/` and `src/tests/supabase/reports/`
- Updated `src/tests/supabase/docs/testing-supabase-connection.adoc` with run instructions
- Added `npm run test:supabase:auth-session` to `package.json`

## Validation
- Ran: `npm run test:supabase:auth-session`
-Steps passed
- Verified:
  - environment variables load
  - `signInWithPassword` returns a session
  - `getSession()` returns the active session
  - `getUser()` resolves the authenticated user
  - `refreshSession()` succeeds
  - `signOut()` clears the session

