### PR TITLE
Order cancellation confirmation staff view

### DIFF
--- a/src/app/staff/ViewOrders.tsx
+++ b/src/app/staff/ViewOrders.tsx
@@ -1,3 +1,5 @@
+import ConfirmationMode from "@/components/confirmation_mode";
+import { mockOrders, type Order } from "@/dummyData/orderData";
 import { Image } from "expo-image";
 import React, { useMemo, useState } from "react";
 import {
@@ -8,8 +10,6 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-
-import { mockOrders, type Order } from "@/dummyData/orderData";
 import lightLogo from "../../../documentation/branding/images/Light-Mode-Logo.png";
 import { FilterBar } from "../../components/FilterBar";
 import { OrderCard } from "../../components/OrderCard";
@@ -151,7 +151,18 @@ function FullScreenOrderDetails({
 }) {
   const statusSymbol =
     order.status === "unread" ? "!" : order.status === "open" ? "..." : "✓";
+  const [closeModalVisible, setCloseModalVisible] = useState(false);
+const [closeReason, setCloseReason] = useState("");
 
+const handleConfirmClose = (reason?: string) => {
+  console.log("Close order:", order.id, "Reason:", reason);
+
+  setCloseModalVisible(false);
+  setCloseReason("");
+
+  onStatusChange(order.id, "finished");
+  onBack();
+};
   return (
     <View style={styles.detailScreen}>
       <View style={styles.detailHeader}>
@@ -260,10 +271,11 @@ function FullScreenOrderDetails({
             order.status === "finished" && styles.disabledButton,
           ]}
           disabled={order.status === "finished"}
-          onPress={() => {
-            onStatusChange(order.id, "finished");
-            onBack();
-          }}
+          onPress={() => setCloseModalVisible(true)}
+          // onPress={() => {
+          //   onStatusChange(order.id, "finished");
+          //   onBack();
+          // }}
         >
           <Text
             style={[
@@ -275,6 +287,14 @@ function FullScreenOrderDetails({
           </Text>
         </TouchableOpacity>
       </View>
+      <ConfirmationMode
+        visible={closeModalVisible}
+        orderNumber={order.orderNumber}
+        reason={closeReason}
+        onReasonChange={setCloseReason}
+        onConfirmCancel={handleConfirmClose}
+        onGoBack={() => setCloseModalVisible(false)}
+/>
     </View>
   );
 }

--- a/src/app/staff/ViewOrders.tsx
+++ b/src/app/staff/ViewOrders.tsx
@@ -61,19 +61,33 @@ export default function ViewOrders() {
 
     return filtered;
   }, [orders, activeTab, sortField, sortDirection]);
-  const handleStatusChange = (orderId: number, newStatus: Order["status"]) => {
-  setOrders((currentOrders) =>
-    currentOrders.map((order) =>
-      order.id === orderId ? { ...order, status: newStatus } : order
-    )
-  );
+  const handleStatusChange = (
+    orderId: number,
+    newStatus: Order["status"],
+    closeReason?: string
+  ) => {
+    setOrders((currentOrders) =>
+      currentOrders.map((order) =>
+        order.id === orderId
+          ? {
+              ...order,
+              status: newStatus,
+              closeReason: newStatus === "open" ? undefined : closeReason || order.closeReason,
+            }
+          : order
+      )
+    );
 
-  setSelectedOrder((currentOrder) =>
-    currentOrder && currentOrder.id === orderId
-      ? { ...currentOrder, status: newStatus }
-      : currentOrder
-  );
-};
+    setSelectedOrder((currentOrder) =>
+      currentOrder && currentOrder.id === orderId
+        ? {
+            ...currentOrder,
+            status: newStatus,
+            closeReason: closeReason || currentOrder.closeReason,
+          }
+        : currentOrder
+    );
+  };
   if (selectedOrder) {
     return (
       <FullScreenOrderDetails
@@ -147,20 +161,21 @@ function FullScreenOrderDetails({
 }: {
   order: Order;
   onBack: () => void;
-  onStatusChange: (orderId: number, newStatus: Order["status"]) => void;
+  onStatusChange: (
+  orderId: number,
+  newStatus: Order["status"],
+  closeReason?: string
+) => void;
 }) {
   const statusSymbol =
     order.status === "unread" ? "!" : order.status === "open" ? "..." : "✓";
   const [closeModalVisible, setCloseModalVisible] = useState(false);
 const [closeReason, setCloseReason] = useState("");
-
 const handleConfirmClose = (reason?: string) => {
-  console.log("Close order:", order.id, "Reason:", reason);
-
   setCloseModalVisible(false);
   setCloseReason("");
 
-  onStatusChange(order.id, "finished");
+  onStatusChange(order.id, "finished", reason);
   onBack();
 };
   return (
@@ -236,6 +251,12 @@ const handleConfirmClose = (reason?: string) => {
               </View>
             ))}
           </View>
+          {order.closeReason && (
+            <View style={styles.closeReasonBox}>
+              <Text style={styles.closeReasonTitle}>Close Reason</Text>
+              <Text style={styles.closeReasonText}>{order.closeReason}</Text>
+            </View>
+          )}
         </View>
       </ScrollView>
 
@@ -249,6 +270,7 @@ const handleConfirmClose = (reason?: string) => {
           disabled={order.status === "open"}
           onPress={() => {
             onStatusChange(order.id, "open");
+            setCloseModalVisible(false)
             onBack();
           }}
         >
@@ -606,6 +628,28 @@ const styles = StyleSheet.create({
   finishedStatusBadge: {
     backgroundColor: "#b1b1b1",
   },
+  closeReasonBox: {
+    marginHorizontal: 20,
+    marginBottom: 20,
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: "#FFF7ED",
+    borderWidth: 1,
+    borderColor: "#FDBA74",
+  },
+
+  closeReasonTitle: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: "#9A3412",
+    marginBottom: 6,
+  },
+
+  closeReasonText: {
+    fontSize: 15,
+    color: "#7C2D12",
+    lineHeight: 21,
+  }
 });
 
 

--- a/src/components/confirmation_mode.tsx
+++ b/src/components/confirmation_mode.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import {
+    Modal,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from "react-native";
+
+type ConfirmationModeProps = {
+  visible: boolean;
+  orderNumber: number;
+  reason: string;
+  onReasonChange: (reason: string) => void;
+  onConfirmCancel: (reason?: string) => void;
+  onGoBack: () => void;
+};
+
+export default function ConfirmationMode({
+  visible,
+  orderNumber,
+  reason,
+  onReasonChange,
+  onConfirmCancel,
+  onGoBack,
+}: ConfirmationModeProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={styles.confirmationOverlay}>
+        <View style={styles.confirmationCard}>
+          <Text style={styles.confirmationTitle}>
+            Close Order #{orderNumber}?
+          </Text>
+
+          <Text style={styles.confirmationMessage}>
+            This action will close the order. Please confirm only if this order is ready or
+            should no longer be prepared.
+          </Text>
+
+          <TextInput
+            value={reason}
+            onChangeText={onReasonChange}
+            placeholder="Optional reason for closing"
+            placeholderTextColor="#8a8a8a"
+            style={styles.reasonInput}
+            multiline
+          />
+
+          <View style={styles.confirmationActions}>
+            <TouchableOpacity
+              activeOpacity={0.75}
+              style={styles.goBackButton}
+              onPress={onGoBack}
+            >
+              <Text style={styles.goBackButtonText}>Go back</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              activeOpacity={0.75}
+              style={styles.confirmCancelButton}
+              onPress={() => onConfirmCancel(reason.trim() || undefined)}
+            >
+              <Text style={styles.confirmCancelButtonText}>
+                Confirm close
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  confirmationOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.45)",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+
+  confirmationCard: {
+    width: "100%",
+    maxWidth: 420,
+    backgroundColor: "#ffffff",
+    borderRadius: 18,
+    padding: 22,
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.2,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+
+  confirmationTitle: {
+    fontSize: 22,
+    fontWeight: "800",
+    color: "#111827",
+    textAlign: "center",
+  },
+
+  confirmationMessage: {
+    fontSize: 15,
+    color: "#4b5563",
+    lineHeight: 22,
+    textAlign: "center",
+    marginTop: 12,
+  },
+
+  reasonInput: {
+    minHeight: 88,
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: "#111827",
+    marginTop: 18,
+    textAlignVertical: "top",
+    backgroundColor: "#f9fafb",
+  },
+
+  confirmationActions: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 20,
+  },
+
+  goBackButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: "#e5e7eb",
+    alignItems: "center",
+  },
+
+  goBackButtonText: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: "#111827",
+  },
+
+  confirmCancelButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: "#dc2626",
+    alignItems: "center",
+  },
+
+  confirmCancelButtonText: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: "#ffffff",
+  },
+});

--- a/src/dummyData/orderData.ts
+++ b/src/dummyData/orderData.ts
@@ -11,6 +11,7 @@ export interface Order {
   createdAt: string;
   items: OrderItem[];
   status: "unread" | "open" | "finished";
+  closeReason?: string;
 }
 
 export const mockOrders: Order[] = [


### PR DESCRIPTION
closes issue #332 
------------------
## to run this page 
open src/app/_layout.tsx and change line 12

export const unstable_settings = {
  anchor: '(tabs)',
};

to 

export const unstable_settings = {
  anchor: 'staff',
};

results will be in the home tab
------------
# images

<img  height="300" alt="Finished" src="https://github.com/user-attachments/assets/89520600-4e8c-4707-852c-c26820616f83" />

opened order # 2

<img height="300" alt="Order #2" src="https://github.com/user-attachments/assets/de233645-8cf5-4dd1-8e57-609eaa4003ef" />

full-screen order #2


<img  height="300" alt="Close Order #2" src="https://github.com/user-attachments/assets/14f168e3-19ca-4a4e-8a07-0a30848f1cb6" />

closed order confirmation pop up

<img  height="200" alt="Close Order #2" src="https://github.com/user-attachments/assets/e2f69025-802a-48ac-8504-590f0f1ac218" />

message written on closed order confirmation pop up

<img height="300" alt="Open" src="https://github.com/user-attachments/assets/eee736d9-df35-4e2d-8cd7-7a13d586df8f" />

order # 2 on finished orders page

<img  height="200" alt="Order #2" src="https://github.com/user-attachments/assets/d1e253c1-c75e-4e0f-a537-247b6786b9c8" />

order # 2 expanded with close message