### PR TITLE
Property-based testing for order state transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "dotenv": "^17.3.1",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~10.0.0",
+        "fast-check": "^4.8.0",
         "jest": "^30.3.0",
         "jest-expo": "^55.0.14",
         "metro-react-native-babel-preset": "^0.77.0",
@@ -11122,6 +11123,46 @@
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@babel/preset-typescript": "^7.28.5",
     "@babel/runtime": "^7.29.2",
     "@cucumber/cucumber": "^12.7.0",
+    "@playwright/test": "^1.44.0",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
@@ -86,6 +87,7 @@
     "dotenv": "^17.3.1",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
+    "fast-check": "^4.8.0",
     "jest": "^30.3.0",
     "jest-expo": "^55.0.14",
     "metro-react-native-babel-preset": "^0.77.0",
@@ -93,8 +95,7 @@
     "react-test-renderer": "19.1.0",
     "ts-node": "^10.9.0",
     "tsx": "^4.21.0",
-    "typescript": "~5.9.2",
-    "@playwright/test": "^1.44.0"
+    "typescript": "~5.9.2"
   },
   "jest": {
     "preset": "jest-expo",

--- a/src/lib/order-state-machine.ts
+++ b/src/lib/order-state-machine.ts
@@ -1,0 +1,45 @@
+/**
+ * Orders state machine definition and utilities.
+ *
+ * This module defines the order states and valid transitions for the cafeteria ordering system.
+ */
+
+export type OrderStatus =
+  | "placed"
+  | "preparing"
+  | "ready"
+  | "completed"
+  | "cancelled";
+
+export const ALL_STATES: OrderStatus[] = [
+  "placed",
+  "preparing",
+  "ready",
+  "completed",
+  "cancelled",
+];
+
+export const TERMINAL_STATES: OrderStatus[] = ["completed", "cancelled"];
+
+// Every (from -> to) pair that the system allows.
+export const VALID_TRANSITIONS: [OrderStatus, OrderStatus][] = [
+  ["placed", "preparing"],
+  ["placed", "ready"],
+  ["placed", "cancelled"],
+  ["preparing", "ready"],
+  ["preparing", "cancelled"],
+  ["ready", "completed"],
+  ["ready", "cancelled"],
+];
+
+export function isValidTransition(from: OrderStatus, to: OrderStatus): boolean {
+  return VALID_TRANSITIONS.some(([f, t]) => f === from && t === to);
+}
+
+export function getValidNextStates(status: OrderStatus): OrderStatus[] {
+  return VALID_TRANSITIONS.filter(([f]) => f === status).map(([, t]) => t);
+}
+
+export function isTerminalState(status: OrderStatus): boolean {
+  return TERMINAL_STATES.includes(status);
+}

--- a/src/tests/staff_operations/cases/TC-STAFF-02_order_state_transitions_pbt.ts
+++ b/src/tests/staff_operations/cases/TC-STAFF-02_order_state_transitions_pbt.ts
@@ -1,0 +1,85 @@
+/**
+ *
+ * TEST CASE: TC-STAFF-02 – Order State Transition Property-Based Tests
+ *
+ * @id          TC-STAFF-02
+ * @author      Reinaldo J. Martinez Morales
+ * @date        2026-05-26
+ * @issue       #537
+ *
+ * @description
+ * Rather than checking a handful of fixed scenarios, these tests define
+ * properties that must hold for every valid input. fast-check generates
+ * hundreds of random cases per property and, when something breaks, shrinks
+ * the failure down to its simplest possible form automatically.
+ *
+ * Test type: Property-based unit testing (Jest + fast-check).
+ *
+ * @preconditions
+ * - The order state machine module is in place and exports its core API:
+ *     OrderStatus, ALL_STATES, TERMINAL_STATES, VALID_TRANSITIONS,
+ *     isValidTransition, getValidNextStates, isTerminalState
+ * - fast-check and Jest are installed and configured.
+ *
+ */
+
+// Order Lifecycle States
+// - placed     -> customer submitted the order
+// - preparing  -> staff acknowledged and is preparing
+// - ready      -> ready for pickup
+// - completed  -> customer collected (terminal)
+// - cancelled  -> cancelled before completion (terminal)
+
+// Valid Transitions (from -> to)
+// 1. placed     -> preparing  (staff opens order via onOpenOrder)
+// 2. placed     -> ready      (staff closes unread order as done)
+// 3. placed     -> cancelled  (staff cancels before starting)
+// 4. preparing  -> ready      (staff finishes preparation)
+// 5. preparing  -> cancelled  (staff cancels while preparing)
+// 6. ready      -> completed  (customer picks up via onPickupConfirm)
+// 7. ready      -> cancelled  (order not collected, edge case)
+
+// Invalid Transitions (sample, not exhaustive)
+// - preparing -> placed     : cannot revert to initial state
+// - ready     -> placed     : cannot revert to initial state
+// - ready     -> preparing  : cannot go backwards
+// - completed -> *any*      : terminal state
+// - cancelled -> *any*      : terminal state
+// - placed    -> completed  : must pass through intermediate states
+// - placed    -> placed     : no self-transitions
+
+// Test Steps and Expected Results
+//
+// P1 – Valid transitions are always accepted
+//   Generator: fc.constantFrom(...VALID_TRANSITIONS)
+//   Assert: isValidTransition(from, to) === true for all 200 samples
+//
+// P2 – Terminal states have no outgoing transitions
+//   Generator: fc.constantFrom('completed','cancelled') × fc.constantFrom(...ALL_STATES)
+//   Assert: isValidTransition(terminalState, anyState) === false
+//
+// P3 – No state transitions to itself
+//   Generator: fc.constantFrom(...ALL_STATES)
+//   Assert: isValidTransition(s, s) === false for every state
+//
+// P4 – getValidNextStates is consistent with VALID_TRANSITIONS
+//   Generator: fc.constantFrom(...ALL_STATES)
+//   Assert: Set(getValidNextStates(s)) exactly matches to-values in VALID_TRANSITIONS for s
+//
+// P5 – Random valid walks are internally consistent
+//   Generator: fc.array(fc.constantFrom(...ALL_STATES), {min:1, max:8}), filtered by fc.pre
+//   Assert: isValidTransition(seq[i], seq[i+1]) === true for every consecutive pair
+//
+// Smoke tests (deterministic)
+//   ST-1: isValidTransition('placed',    'preparing') === true
+//   ST-2: isValidTransition('ready',     'completed') === true
+//   ST-3: isValidTransition('completed', 'placed')    === false
+//   ST-4: isValidTransition('cancelled', 'preparing') === false
+//   ST-5: isTerminalState('completed') && isTerminalState('cancelled') &&
+//         !isTerminalState('placed') && !isTerminalState('preparing') && !isTerminalState('ready')
+
+// Notes
+// - fast-check auto-shrinks failures to the simplest counterexample
+
+export { };
+

--- a/src/tests/staff_operations/docs/order_state_transitions_pbt_summary.adoc
+++ b/src/tests/staff_operations/docs/order_state_transitions_pbt_summary.adoc
@@ -1,0 +1,112 @@
+= Order State Transition Property-Based Testing — Strategy Summary
+Author: Reinaldo J. Martinez Morales
+:toc:
+:toc-placement: preamble
+
+*Issue:* #537 +
+*Test Case:* TC-STAFF-02 +
+*Test Report:* TR-STAFF-02 +
+*Date:* 2026-05-26
+
+== Overview
+
+The order lifecycle has exactly 7 allowed transitions across 5 states.  You could write one test per path and call, but that misses what happens when transitions get chained or the state machine receives a combination nobody thought to include.  fast-check generates the inputs, so edge cases surface from the tool rather than scenarios we imagined.  If a property fails, it shrinks the counter example down automatically, which makes it easier to note what broke.
+
+== Order Lifecycle State Machine
+
+The state machine is encoded in `src/lib/order-state-machine.ts` and mirrors the transitions implemented in staff operations orders screen.
+
+=== States
+
+[cols="1,3,1", options="header"]
+|===
+| Status | Description | Terminal?
+
+| `placed`
+| Customer has submitted the order; awaiting staff action
+| No
+
+| `preparing`
+| Staff opened the order and is actively preparing it
+| No
+
+| `ready`
+| Preparation complete; awaiting customer pickup
+| No
+
+| `completed`
+| Customer collected the order
+| *Yes*
+
+| `cancelled`
+| Order cancelled at any pre-collection stage
+| *Yes*
+|===
+
+=== Valid Transitions
+
+[cols="1,1,2", options="header"]
+|===
+| From | To | Trigger
+
+| `placed` | `preparing` | Staff opens unread order (`onOpenOrder`)
+| `placed` | `ready` | Staff closes unread order as done (`onCloseOrder("completed")`)
+| `placed` | `cancelled` | Staff cancels before starting (`onCloseOrder("cancelled")`)
+| `preparing` | `ready` | Staff finishes preparation
+| `preparing` | `cancelled` | Staff cancels during preparation
+| `ready` | `completed` | Customer picks up (`onPickupConfirm`)
+| `ready` | `cancelled` | Order not collected (edge case)
+|===
+
+All other transitions (e.g., `completed to placed`, `preparing to placed`, `ready to preparing`) are **invalid** and must be rejected.
+
+== Properties Tested
+
+=== Property 1 — Valid transitions are always accepted
+
+Sanity check: every `(from, to)` pair in `VALID_TRANSITIONS` should return `true` from `isValidTransition`. +
+Generator: `fc.constantFrom(...VALID_TRANSITIONS)`, 7 possible pairs, 200 runs. +
+Catches a typo or off-by-one in the lookup that would silently reject a transition the workflow needs.
+
+=== Property 2 — Terminal states have no outgoing transitions
+
+`completed` and `cancelled` are end states, so nothing should follow them. +
+Feeds all `(terminal, anyState)` combinations into `isValidTransition` and expects `false` every time. +
+200 samples across both terminal states × all 5 states.
+
+=== Property 3 — Non-reflexivity (no self-transitions)
+
+`isValidTransition(s, s)` must be `false` for every status. A self-transition is a silent no-op and could mask real bugs if accidentally accepted. Short property: 200 samples over all 5 states.
+
+=== Property 4 — `getValidNextStates` is consistent with `VALID_TRANSITIONS`
+
+`isValidTransition` and `getValidNextStates` both expose the transition data through different call surfaces. +
+If someone updates `VALID_TRANSITIONS` and forgets to keep `getValidNextStates` in sync, they drift apart in ways that can be hard to notice. +
+This property checks that for every state the set returned by `getValidNextStates(s)` exactly matches what you'd compute directly from `VALID_TRANSITIONS`. 200 samples.
+
+=== Property 5 — Random valid walks are internally consistent
+
+The generator builds random state sequences (length 1–8); `fc.pre` filters out any that aren't already valid walks, so only realistic order progressions reach the assertions.
+
+- *5a:* Every consecutive pair in the walk satisfies `isValidTransition`.
+- *5b:* In any walk starting from `placed`, a terminal state may only appear as the last element, nothing follows `completed` or `cancelled`.
+
+500 samples. Most generated sequences get discarded by `fc.pre`; the count reflects passing pre-conditions only.
+
+== Shrinking
+
+No failures were found during this run (TR-STAFF-02).  The shrinking infrastructure is in place to aid debugging should a future code change break any property.
+
+== Running the Tests
+
+[source,bash]
+----
+# Run TC-STAFF-02 only
+npx jest --config jest.config.js TC-STAFF-02 --verbose
+
+----
+
+== Results
+
+All 11 tests passed across 1 800+ generated samples in ~0.7 s. +
+Check TR-STAFF-02 for the full execution log.

--- a/src/tests/staff_operations/reports/TR-STAFF-02_order_state_transitions_pbt.adoc
+++ b/src/tests/staff_operations/reports/TR-STAFF-02_order_state_transitions_pbt.adoc
@@ -1,0 +1,116 @@
+= TR-STAFF-02 Order State Transition Property-Based Tests
+Author: Reinaldo J. Martinez Morales
+
+*Date:* 2026-05-26
+
+*ID:* TR-STAFF-02
+
+*Issue:* #537
+
+*Test:* TC-STAFF-02 – Order State Transition Property-Based Tests
+
+*Pass/Fail Status:* PASS
+
+== Description
+
+All 11 tests executed successfully across 5 property-based `fc.assert` calls (200–500 random samples each) plus 5 deterministic smoke tests.
+
+=== Test Execution Summary
+
+[cols="1,4,1,1", options="header"]
+|===
+| Group | Test | Samples | Result
+
+| Smoke tests
+| ST-1: placed → preparing is valid
+| 1 (deterministic)
+| PASS
+
+| Smoke tests
+| ST-2: ready → completed is valid
+| 1 (deterministic)
+| PASS
+
+| Smoke tests
+| ST-3: completed → placed is invalid (backwards)
+| 1 (deterministic)
+| PASS
+
+| Smoke tests
+| ST-4: cancelled → preparing is invalid (terminal)
+| 1 (deterministic)
+| PASS
+
+| Smoke tests
+| ST-5: isTerminalState correctly classifies all states
+| 1 (deterministic)
+| PASS
+
+| Property 1
+| isValidTransition returns true for all pairs in VALID_TRANSITIONS
+| 200
+| PASS
+
+| Property 2
+| isValidTransition returns false for all (terminal, any) pairs
+| 200
+| PASS
+
+| Property 3
+| isValidTransition(s, s) is false for every state s
+| 200
+| PASS
+
+| Property 4
+| getValidNextStates returns exactly the expected successors for every state
+| 200
+| PASS
+
+| Property 5a
+| Every consecutive pair in a valid-transition walk is accepted
+| 500
+| PASS
+
+| Property 5b
+| Terminal states always appear as the final step of any valid walk from placed
+| 500
+| PASS
+|===
+
+Total tests: 11 / 11 passed. +
+Total property samples run: 1800+. +
+No counterexamples found. +
+Wall time: ~0.7 s.
+
+=== Raw Jest Output
+
+----
+ PASS  src/tests/staff_operations/scripts/TC-STAFF-02_order_state_transitions_pbt.test.ts
+  Smoke tests – specific known transitions
+    ✓ ST-1: placed → preparing is valid (1 ms)
+    ✓ ST-2: ready → completed is valid
+    ✓ ST-3: completed → placed is invalid (backwards)
+    ✓ ST-4: cancelled → preparing is invalid (terminal)
+    ✓ ST-5: isTerminalState correctly classifies all states
+  Property 1 – every defined valid transition is accepted
+    ✓ isValidTransition returns true for all pairs in VALID_TRANSITIONS (2 ms)
+  Property 2 – terminal states cannot transition to any state
+    ✓ isValidTransition returns false for all (terminal, any) pairs
+  Property 3 – no state can transition to itself
+    ✓ isValidTransition(s, s) is false for every state s
+  Property 4 – getValidNextStates matches VALID_TRANSITIONS
+    ✓ for every state, getValidNextStates returns exactly the expected successors (1 ms)
+  Property 5 – randomly generated valid walks are consistent
+    ✓ every consecutive pair in a valid-transition walk is accepted (75 ms)
+    ✓ completed and cancelled states always appear as the final step of any shrunk walk (139 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       11 passed, 11 total
+Snapshots:   0 total
+Time:        0.394 s, estimated 1 s
+Ran all test suites matching TC-STAFF-02.
+----
+
+=== Shrinking
+
+No property violations were found, so fast-check's shrinking was not triggered.  The shrinking setup is in place: if a future code change introduces an invalid transition into `VALID_TRANSITIONS` or breaks `isValidTransition`, fast-check will automatically report the minimal (from, to) pair or shortest walk that demonstrates the failure.

--- a/src/tests/staff_operations/scripts/TC-STAFF-02_order_state_transitions_pbt.test.ts
+++ b/src/tests/staff_operations/scripts/TC-STAFF-02_order_state_transitions_pbt.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Property-Based Tests: Order State Transitions
+ *
+ * @id      TC-STAFF-02
+ * @author  Reinaldo J. Martinez Morales
+ * @issue   #537
+ *
+ * Five properties verified via fast-check over the pure state machine defined
+ * in order-state-machine.ts. Fast-check generates random inputs and
+ * automatically shrinks any failing case to its minimal counterexample.
+ *
+ */
+
+import fc from "fast-check";
+import {
+  ALL_STATES,
+  getValidNextStates,
+  isTerminalState,
+  isValidTransition,
+  VALID_TRANSITIONS,
+  type OrderStatus,
+} from "../../../lib/order-state-machine";
+
+const anyState = fc.constantFrom<OrderStatus>(...ALL_STATES);
+
+const terminalState = fc.constantFrom<OrderStatus>("completed", "cancelled");
+
+const validPair = fc.constantFrom<[OrderStatus, OrderStatus]>(
+  ...VALID_TRANSITIONS,
+);
+
+const stateSequence = fc.array(anyState, { minLength: 1, maxLength: 8 });
+
+function setsEqual(a: OrderStatus[], b: OrderStatus[]): boolean {
+  if (a.length !== b.length) return false;
+  const setA = new Set(a);
+  return b.every((x) => setA.has(x));
+}
+
+function expectedNextStates(status: OrderStatus): OrderStatus[] {
+  return VALID_TRANSITIONS.filter(([f]) => f === status).map(([, t]) => t);
+}
+
+describe("Smoke tests – specific known transitions", () => {
+  it("ST-1: placed → preparing is valid", () => {
+    expect(isValidTransition("placed", "preparing")).toBe(true);
+  });
+
+  it("ST-2: ready → completed is valid", () => {
+    expect(isValidTransition("ready", "completed")).toBe(true);
+  });
+
+  it("ST-3: completed → placed is invalid (backwards)", () => {
+    expect(isValidTransition("completed", "placed")).toBe(false);
+  });
+
+  it("ST-4: cancelled → preparing is invalid (terminal)", () => {
+    expect(isValidTransition("cancelled", "preparing")).toBe(false);
+  });
+
+  it("ST-5: isTerminalState correctly classifies all states", () => {
+    expect(isTerminalState("completed")).toBe(true);
+    expect(isTerminalState("cancelled")).toBe(true);
+    expect(isTerminalState("placed")).toBe(false);
+    expect(isTerminalState("preparing")).toBe(false);
+    expect(isTerminalState("ready")).toBe(false);
+  });
+});
+
+describe("Property 1 – every defined valid transition is accepted", () => {
+  it("isValidTransition returns true for all pairs in VALID_TRANSITIONS", () => {
+    fc.assert(
+      fc.property(validPair, ([from, to]) => {
+        return isValidTransition(from, to) === true;
+      }),
+      { numRuns: 200, verbose: true },
+    );
+  });
+});
+
+describe("Property 2 – terminal states cannot transition to any state", () => {
+  it("isValidTransition returns false for all (terminal, any) pairs", () => {
+    fc.assert(
+      fc.property(terminalState, anyState, (from, to) => {
+        return isValidTransition(from, to) === false;
+      }),
+      { numRuns: 200, verbose: true },
+    );
+  });
+});
+
+describe("Property 3 – no state can transition to itself", () => {
+  it("isValidTransition(s, s) is false for every state s", () => {
+    fc.assert(
+      fc.property(anyState, (s) => {
+        return isValidTransition(s, s) === false;
+      }),
+      { numRuns: 200, verbose: true },
+    );
+  });
+});
+
+describe("Property 4 – getValidNextStates matches VALID_TRANSITIONS", () => {
+  it("for every state, getValidNextStates returns exactly the expected successors", () => {
+    fc.assert(
+      fc.property(anyState, (s) => {
+        return setsEqual(getValidNextStates(s), expectedNextStates(s));
+      }),
+      { numRuns: 200, verbose: true },
+    );
+  });
+});
+
+describe("Property 5 – randomly generated valid walks are consistent", () => {
+  it("every consecutive pair in a valid-transition walk is accepted", () => {
+    fc.assert(
+      fc.property(stateSequence, (seq) => {
+        fc.pre(
+          seq.length >= 2 &&
+            seq.slice(0, -1).every((s, i) => isValidTransition(s, seq[i + 1])),
+        );
+
+        return seq
+          .slice(0, -1)
+          .every((s, i) => isValidTransition(s, seq[i + 1]));
+      }),
+      { numRuns: 500, verbose: true },
+    );
+  });
+
+  it("completed and cancelled states always appear as the final step of any shrunk walk", () => {
+    fc.assert(
+      fc.property(stateSequence, (seq) => {
+        fc.pre(seq.length >= 2);
+        fc.pre(seq[0] === "placed");
+        fc.pre(
+          seq.slice(0, -1).every((s, i) => isValidTransition(s, seq[i + 1])),
+        );
+
+        const terminalIdx = seq.findIndex(isTerminalState);
+
+        if (terminalIdx === -1) return true;
+
+        return terminalIdx === seq.length - 1;
+      }),
+      { numRuns: 500, verbose: true },
+    );
+  });
+});

--- a/src/tests/trackers/test_case_tracker.adoc
+++ b/src/tests/trackers/test_case_tracker.adoc
@@ -14,4 +14,5 @@
 |TC-ORD-02 |Validate Order ID format and correctness of generated values for place and confirm order feature. | UT-ORD-2_Place_and_Confirmation_for_Order.ts
 |TC-PAY-01 |Payment confirmation verification |TBD 
 |TC-ORD-03 | Menu item attribute validation tests | src/tests/ordering/scrips/TC-ORD-03-menu-item-script.ts
+|TC-STAFF-02 | Order State Transition Property-Based Tests — validates order lifecycle with fast-check (placed, preparing, ready, completed, cancelled) | src/tests/staff_operations/scripts/TC-STAFF-02_order_state_transitions_pbt.test.ts
 |====

--- a/src/tests/trackers/test_report_tracker.adoc
+++ b/src/tests/trackers/test_report_tracker.adoc
@@ -9,4 +9,5 @@
 |TR-ORD-2 |Report that unit test outputs for Order ID generation are correct, including format validation and handling of invalid or undefined values |
 |TR-AUTH-03 |Test report for User Sign Up functionality with valid data, including UI verification, happy path, negative test scenarios, form recovery, and optional phone number validation |src/tests/authentication/scripts/signup_valid_data.test.tsx
 |TR-AUTH-04 |Test report for Account Verification Process including valid token verification, invalid/expired tokens, resend verification email, already verified account handling, and empty/missing token validation |src/tests/authentication/scripts/verification.test.tsx
+|TR-STAFF-02 |Property-based test report for order state transitions — 11 tests, 1800+ random samples, all passed | src/tests/staff_operations/scripts/TC-STAFF-02_order_state_transitions_pbt.test.ts
 |====


### PR DESCRIPTION
A property-based testing was made to order state transitions. A test report, test cases and code was generated to do the test.

Closes #537 